### PR TITLE
added 'gemfile' subcommand

### DIFF
--- a/exe/stoat
+++ b/exe/stoat
@@ -14,6 +14,7 @@ module Stoat
       no_command
       footer <<~FOOTER
         Subcommands:
+          - gemfile: Update Gemfile and related files
           - perf: Fetch and evaluate the latest perf test results
       FOOTER
     end
@@ -24,6 +25,12 @@ module Stoat
       short '-h'
       long '--help'
       desc 'Show usage help'
+    end
+
+    option :path do
+      short '-p string'
+      long '--path string'
+      desc 'Path to a root dir to look for content in'
     end
 
     flag :version do
@@ -56,6 +63,8 @@ module Stoat
 
     def handle_subcommand
       case params[:subcommand]
+      when 'gemfile'
+        Stoat::Gemfile.new(params[:path]).go
       when 'perf'
         Stoat::Perf.new.go
       else

--- a/lib/stoat.rb
+++ b/lib/stoat.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'stoat/helpers'
+require_relative 'stoat/gemfile'
 require_relative 'stoat/perf'
 require_relative 'stoat/version'

--- a/lib/stoat/gemfile.rb
+++ b/lib/stoat/gemfile.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'octokit'
+
+require_relative 'gemfile_helpers'
+require_relative 'helpers'
+
+module Stoat
+  # Gemfile - for updating Gemfile and other project files
+  class Gemfile
+    include GemfileHelpers
+    include Helpers
+
+    attr_reader :data, :path
+
+    def initialize(path = nil)
+      @path = path || Dir.pwd
+      @data = { original: {}, modified: {} }
+    end
+
+    def go
+      read_files
+      modify_files
+    end
+
+    private
+
+    def file_class
+      File
+    end
+
+    def fileutils_class
+      FileUtils
+    end
+
+    def modify_files
+      modify_data
+      overwrite_files
+    end
+
+    def overwrite_files
+      [GEMFILE, LOCKFILE, PAPERSFILE].each do |file|
+        verify_file_changes(file)
+        full = file_class.join(path, file)
+        fileutils_class.rm_f(full)
+        file_class.write(full, data[:modified][file].join)
+      end
+    end
+
+    def read_file(full_path, filename)
+      data[:original][filename] = file_class.read(full_path).lines
+      data[:modified][filename] = []
+    end
+
+    def read_files
+      [GEMFILE, LOCKFILE, PAPERSFILE].each do |file|
+        full = file_class.join(path, file)
+        bail "No '#{file}' file found at #{path}!" unless file_class.exist?(full)
+
+        read_file(full, file)
+      end
+    end
+
+    def release_query
+      <<~QUERY
+        query {
+          repository(owner: "#{repo_owner}", name: "#{repo_name}") {
+            releases(last: 1, orderBy: { field: CREATED_AT, direction: ASC }) {
+              nodes {
+                name
+                tagCommit { oid }
+              }
+            }
+          }
+        }
+      QUERY
+    end
+
+    def repo_owner
+      @repo_owner ||= REPO.split('/').first
+    end
+
+    def repo_name
+      @repo_name ||= REPO.split('/').last
+    end
+
+    def verify_file_changes(file)
+      bail "Failed to modify '#{file}'!" if data[:original][file] == data[:modified][file]
+    end
+  end
+end

--- a/lib/stoat/gemfile_helpers.rb
+++ b/lib/stoat/gemfile_helpers.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Stoat
+  # GemfileHelpers: helper methods for use by Stoat::Gemfile
+  module GemfileHelpers
+    GEMFILE = 'Gemfile'
+    LOCKFILE = 'Gemfile.lock'
+    PAPERSFILE = 'config/papers_manifest.yml'
+
+    def inside_desired_git_block?(line)
+      return true if @inside_desired_git_block
+
+      # return true on the next line, false for this one
+      @inside_desired_git_block = true if line.match?(%r{newrelic/newrelic-ruby-agent})
+      false
+    end
+
+    def latest_release
+      @latest_release ||= begin
+        response = github.post '/graphql', { query: release_query }.to_json
+        response.data.repository.releases.nodes.first
+      end
+    rescue StandardError => e
+      bail "Failed to fetch latest release for '#{Stoat::Helpers::REPO}' from GitHub: #{e.class} - #{e.message}"
+    end
+
+    def latest_sha
+      @latest_sha ||= latest_release.tagCommit.oid
+    end
+
+    def latest_version
+      @latest_version ||= latest_release.name
+    end
+
+    def latest_version_without_pre
+      latest_version.sub(/-pre$/, '')
+    end
+
+    def lockfile_processing_complete?
+      @lockfile_processing_complete
+    end
+
+    def modify_data
+      modify_data_gemfile
+      modify_data_lockfile
+      modify_data_papersfile
+    end
+
+    def modify_data_gemfile
+      data[:original][GEMFILE].each do |line|
+        data[:modified][GEMFILE] << modify_data_gemfile_line(line)
+      end
+    end
+
+    def modify_data_gemfile_line(line)
+      return line unless line =~ /^(\s*gem 'newrelic(?:_rpm|-infinite_tracing)', git: .*?, tag: )(['"])[^'"]+['"](.*?)$/
+
+      start = Regexp.last_match(1)
+      quote = Regexp.last_match(2)
+      finish = Regexp.last_match(4)
+      "#{start}#{quote}#{latest_version}#{quote}#{finish}\n"
+    end
+
+    def modify_data_lockfile
+      data[:original][LOCKFILE].each_with_index do |line, idx|
+        process_lockfile_line(line)
+        if lockfile_processing_complete?
+          data[:modified][LOCKFILE] += data[:original][LOCKFILE][idx..]
+          break
+        end
+      end
+    end
+
+    def process_lockfile_line(line)
+      return data[:modified][LOCKFILE] << line unless inside_desired_git_block?(line)
+
+      if line.start_with?('GIT')
+        @lockfile_processing_complete = true
+        return
+      end
+
+      data[:modified][LOCKFILE] << modify_data_lockfile_line(line)
+      false
+    end
+
+    def modify_data_lockfile_line(line)
+      case line
+      when /revision: (\w+)/
+        line.sub(Regexp.last_match(1), latest_sha)
+      when /tag: (.*)/
+        line.sub(Regexp.last_match(1), latest_version)
+      when /newrelic-infinite_tracing \((.*?)\)/, /newrelic_rpm \((?:= )?(.*?)\)/
+        line.sub(Regexp.last_match(1), latest_version_without_pre)
+      else
+        line
+      end
+    end
+
+    def modify_data_papersfile
+      @papers_modifications = 0
+      data[:original][PAPERSFILE].each_with_index do |line, idx|
+        process_papers_line(line)
+        if @papers_modifications == 2
+          data[:modified][PAPERSFILE] += data[:original][PAPERSFILE][(idx + 1)..]
+          break
+        end
+      end
+    end
+
+    def process_papers_line(line)
+      if line =~ /^(\s*newrelic(?:_rpm|-infinite_tracing)-)[^:]+(:.*)$/
+        data[:modified][PAPERSFILE] << "#{Regexp.last_match(1)}#{latest_version}#{Regexp.last_match(2)}\n"
+        @papers_modifications += 1
+      else
+        data[:modified][PAPERSFILE] << line
+      end
+    end
+  end
+end

--- a/lib/stoat/helpers.rb
+++ b/lib/stoat/helpers.rb
@@ -1,11 +1,28 @@
 # frozen_string_literal: true
 
+require 'octokit'
+
 module Stoat
   # Helpers: helper methods for use by all subcommands
   module Helpers
+    TOKEN_ENV_VAR = 'NR_GITHUB_TOKEN'
+    REPO = 'newrelic/newrelic-ruby-agent'
+
+    def access_token
+      @access_token ||= begin
+        bail "GitHub Access Token env var '#{TOKEN_ENV_VAR}' not set!" unless ENV.key?(TOKEN_ENV_VAR)
+
+        ENV.fetch(TOKEN_ENV_VAR)
+      end
+    end
+
     def bail(msg)
       warn msg
       exit(1)
+    end
+
+    def github
+      @github ||= Octokit::Client.new(access_token:)
     end
   end
 end

--- a/lib/stoat/version.rb
+++ b/lib/stoat/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stoat
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/stoat.gemspec
+++ b/stoat.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tty-option', '~> 0.2'
 
   spec.add_development_dependency 'minitest', '~> 5.16'
+  spec.add_development_dependency 'pry', '~> 0.14'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.22'

--- a/test/test_gemfile.rb
+++ b/test/test_gemfile.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'test_helper'
+require 'tmpdir'
+
+# TestGemfile - test lib/gemfile.rb
+# rubocop:disable Metrics/ClassLength
+class TestGemfile < Minitest::Test
+  def test_go
+    Dir.mktmpdir do |dir|
+      write_original_files(dir)
+      stoat = fresh_gemfile(dir)
+      stoat.instance_variable_set(:@latest_release, fake_release)
+      stoat.go
+      verify_modifications(dir)
+    end
+  end
+
+  def test_latest_release
+    stoat = fresh_gemfile(nil)
+    def stoat.github
+      mock = MiniTest::Mock.new
+
+      # rubocop:disable Style/OpenStructUse
+      r = OpenStruct.new(data: OpenStruct.new(repository: OpenStruct.new(releases: OpenStruct.new(nodes: %w[node]))))
+      # rubocop:enable Style/OpenStructUse
+      mock.expect :post, r, ['/graphql', String]
+      mock
+    end
+    stoat.send(:latest_release)
+  end
+
+  def test_latest_release_fetch_fails
+    stoat = fresh_gemfile(nil)
+    def stoat.warn(msg)
+      raise "Stoat warned about something unexpected: >#{msg}<" unless msg.match?('kaboom')
+    end
+
+    def stoat.github
+      raise 'Earth shattering kaboom'
+    end
+    assert_raises(SystemExit) { stoat.send(:latest_release) }
+  end
+
+  def test_read_files_when_a_file_is_absent
+    Dir.mktmpdir do |dir|
+      stoat = fresh_gemfile(dir)
+      def stoat.warn(msg)
+        raise "Stoat warned about something unexpected: >#{msg}<" unless msg.start_with?(/No '\w+' file/)
+      end
+      assert_raises(SystemExit) { stoat.send(:read_files) }
+    end
+  end
+
+  def test_release_query
+    stoat = fresh_gemfile(nil)
+    query = stoat.send(:release_query)
+
+    unless query.split("\n")[1] =~ /owner: "([^"]+)", name: "([^"]+)"/
+      raise 'The release query does not appear to be formatted correctly!'
+    end
+
+    repo = [Regexp.last_match(1), Regexp.last_match(2)].join('/')
+    assert_equal Stoat::Helpers::REPO, repo
+  end
+
+  def test_verify_file_changes
+    stoat = fresh_gemfile(nil)
+    file = 'Bingdao'
+
+    def stoat.warn(msg)
+      raise "Stoat warned about something unexpected: >#{msg}<" unless msg.start_with?('Failed to modify')
+    end
+
+    content = 'Same old'
+    stoat.instance_variable_set(:@data, { original: { file => content }, modified: { file => content } })
+    assert_raises(SystemExit) { stoat.send(:verify_file_changes, file) }
+  end
+
+  # helpers
+
+  def fake_release
+    Struct.new('FakeCommit', :oid)
+    commit = Struct::FakeCommit.new(latest_sha)
+    Struct.new('FakeRelease', :tagCommit, :name)
+    Struct::FakeRelease.new(commit, latest_version)
+  end
+
+  def fresh_gemfile(path)
+    Stoat::Gemfile.new(path)
+  end
+
+  def gemfile_content(gem_version)
+    <<~GEMFILE
+      # frozen_string_literal: true
+
+      source 'https://rubygems.org'
+
+      gem 'awesome_print'
+      gem 'interactive_editor'
+      gem 'neovim'
+
+      gem 'newrelic_rpm', git: 'https://github.com/newrelic/newrelic-ruby-agent.git', tag: '#{gem_version}'
+      gem 'newrelic-infinite_tracing', git: 'https://github.com/newrelic/newrelic-ruby-agent.git', tag: '#{gem_version}'
+
+      gem 'pry'
+      gem 'rubocop'
+      gem 'vimgolf'
+    GEMFILE
+  end
+
+  def latest_sha
+    'eb538f5df3198027e1049d318083000a'
+  end
+
+  def latest_version
+    '1.1.3.8'
+  end
+
+  def lockfile_content(gem_version, sha)
+    <<~GEMFILE_LOCK
+      GIT
+        remote: https://github.com/jberkel/interactive_editor.git
+        revision: f32bf2b129716070df6a45c516df3bffb0272a9d
+        tag: v0.0.11
+        specs:
+          interactive_editor (0.0.11)
+
+      GIT
+        remote: https://github.com/newrelic/newrelic-ruby-agent.git
+        revision: #{sha}
+        tag: #{gem_version}
+        specs:
+          newrelic-infinite_tracing (#{gem_version})
+            grpc (~> 1.34)
+            newrelic_rpm (= #{gem_version})
+          newrelic_rpm (#{gem_version})
+
+      GIT
+        remote: https://github.com/pry/pry.git
+        revision: v0aae8c94ad03a732659ed56dcd5088469a15eebf
+        tag: v0.14.1
+        specs:
+          pry (0.14.1)
+
+      PLATFORMS
+        arm64-darwin
+        arm64-darwin-20
+        arm64-darwin-21
+        ruby
+        x86_64-darwin
+        x86_64-darwin-18
+        x86_64-darwin-19
+        x86_64-darwin-20
+        x86_64-darwin-21
+        x86_64-linux
+
+      DEPENDENCIES
+        interactive_editor!
+        newrelic_rpm!
+        pry!
+    GEMFILE_LOCK
+  end
+
+  def original_sha
+    '105ecfe9f555344c13d5e337c65dfa41'
+  end
+
+  def original_version
+    '0.0.7'
+  end
+
+  def papers_content(gem_version)
+    <<~PAPERS
+      #
+      # http://github.com/newrelic/papers
+      ---
+      gems:
+        scientist-1.6.3:
+          license: MIT
+          license_url: https://github.com/github/scientist/blob/main/LICENSE.txt
+          project_url: https://github.com/github/scientist
+        newrelic_rpm-#{gem_version}:
+          license: Apache 2.0
+          license_url: http://www.apache.org/licenses/
+          project_url: https://github.com/newrelic/newrelic-ruby-agent
+        grpc-1.48.0:
+            license: Apache 2.0
+            license_url: https://github.com/grpc/grpc/blob/master/LICENSE
+            project_url: https://github.com/grpc/grpc
+        newrelic-infinite_tracing-#{gem_version}:
+            license: New Relic
+            license_url: https://github.com/newrelic/newrelic-ruby-agent
+            project_url: https://github.com/newrelic/newrelic-ruby-agent
+    PAPERS
+  end
+
+  def prep_subdirectories(dir)
+    [Stoat::GemfileHelpers::GEMFILE, Stoat::GemfileHelpers::LOCKFILE, Stoat::GemfileHelpers::PAPERSFILE].each do |path|
+      FileUtils.mkdir_p File.join(dir, File.dirname(path))
+    end
+  end
+
+  def verify_modifications(dir)
+    modified_gemfile = File.read(File.join(dir, Stoat::GemfileHelpers::GEMFILE))
+    assert_equal gemfile_content(latest_version), modified_gemfile
+
+    modified_lockfile = File.read(File.join(dir, Stoat::GemfileHelpers::LOCKFILE))
+    assert_equal lockfile_content(latest_version, latest_sha), modified_lockfile
+
+    modified_papersfile = File.read(File.join(dir, Stoat::GemfileHelpers::PAPERSFILE))
+    assert_equal papers_content(latest_version), modified_papersfile
+  end
+
+  def write_original_files(dir)
+    prep_subdirectories(dir)
+    File.write(File.join(dir, Stoat::GemfileHelpers::GEMFILE), gemfile_content(original_version))
+    File.write(File.join(dir, Stoat::GemfileHelpers::LOCKFILE), lockfile_content(original_version, original_sha))
+    File.write(File.join(dir, Stoat::GemfileHelpers::PAPERSFILE), papers_content(original_version))
+  end
+end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
stoat now knows how to modify a Ruby project's `Gemfile`, `Gemfile.lock`, and `config/papers_manifest.yml` files to reference the latest version of the New Relic Ruby agent gems.

Run `stoat gemfile` inside a Ruby project root, or run `stoat gemfile -p /path/to/root` from elsewhere.