### PR TITLE
'coverage' subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 stoat*.gem
 Gemfile.lock
+coverage-report-combined

--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ with various chores related to releasing new gem versions.
 - Run `gem install --local stoat`
 
 
-## Usage
-
-After installation, the executable `stoat` binary should be in your PATH.
-
-Run `stoat`, `stoat -h` or `stoat --help` for usage information.
+## Setup
 
 To perform GitHub based operations, you will need to obtain a personal access
 token for dedicated New Relic usage. To create a new token, head to
@@ -33,12 +29,22 @@ export NR_GITHUB_TOKEN=f0x_AnDb@dg3rG0outF0r@4unTt0g3th3RT0n1ght
 ```
 
 
+## Usage
+
+After installation, the executable `stoat` binary should be in your PATH.
+
+Run `stoat`, `stoat -h` or `stoat --help` for usage information.
+
+The following subcommands are offered:
+
+- `stoat coverage`: Fetch and view the latest combined code coverage artifact
+- `stoat gemfile --path /path/to/app`: Update an app's Bundler and Papers files
+- `stoat perf`: Fetch and evaluate the latest perf tests artifact
+
+
 ## Development
 
 - Clone the repo
 - Run `bin/setup` to install dependencies
 - Run `bundle exec rake` to run the tests and linter
 - Open `coverage/index.html` to view code coverage results
-
-
-

--- a/exe/stoat
+++ b/exe/stoat
@@ -14,6 +14,7 @@ module Stoat
       no_command
       footer <<~FOOTER
         Subcommands:
+          - coverage: Fetch the latest code coverage results
           - gemfile: Update Gemfile and related files
           - perf: Fetch and evaluate the latest perf test results
       FOOTER
@@ -63,6 +64,8 @@ module Stoat
 
     def handle_subcommand
       case params[:subcommand]
+      when 'coverage'
+        Stoat::Coverage.new.go
       when 'gemfile'
         Stoat::Gemfile.new(params[:path]).go
       when 'perf'

--- a/lib/stoat.rb
+++ b/lib/stoat.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'stoat/coverage'
 require_relative 'stoat/gemfile'
 require_relative 'stoat/perf'
 require_relative 'stoat/version'

--- a/lib/stoat/artifact_helpers.rb
+++ b/lib/stoat/artifact_helpers.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'zip'
+
+require_relative 'helpers'
+
+module Stoat
+  # ArtifactHelpers - common methods related to GitHub Actions artifacts
+  module ArtifactHelpers
+    include Helpers
+
+    # TODO: error handling
+    def artifact_url(artifact_name)
+      artifacts.detect { |a| a.name == artifact_name }.archive_download_url
+    end
+
+    def artifacts
+      @artifacts ||= github.repository_artifacts(REPO).artifacts
+    end
+
+    def fetch_artifact(artifact_name, cleanup_routine: nil)
+      blob = grab_latest_zip_blob(artifact_name)
+      store_zip(artifact_name, blob)
+      unzip_zip(artifact_name)
+      run_cleanup(artifact_name, cleanup_routine)
+    end
+
+    def file_utils
+      @file_utils ||= FileUtils
+    end
+
+    def grab_latest_zip_blob(artifact_name)
+      github.get(artifact_url(artifact_name))
+    end
+
+    def perform_in_dir(dir)
+      opwd = Dir.pwd
+      Dir.chdir dir
+      yield
+    ensure
+      Dir.chdir opwd
+    end
+
+    def run_cleanup(artifact_name, cleanup_routine)
+      perform_in_dir(artifact_name) { cleanup_routine&.call }
+    end
+
+    def store_zip(artifact_name, blob)
+      FileUtils.rm_rf artifact_name
+      FileUtils.mkdir artifact_name
+      perform_in_dir(artifact_name) { File.write("#{artifact_name}.zip", blob) }
+    end
+
+    def unzip_zip(artifact_name)
+      perform_in_dir(artifact_name) do
+        zip = "#{artifact_name}.zip"
+        Zip::File.open(zip) { |z| z.map(&:extract) }
+        file_utils.rm_rf(zip)
+      end
+    end
+  end
+end

--- a/lib/stoat/coverage.rb
+++ b/lib/stoat/coverage.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+
+require_relative 'artifact_helpers'
+require_relative 'helpers'
+
+module Stoat
+  # Coverage - for fetching the most recent test coverage artifact
+  class Coverage
+    include ArtifactHelpers
+    include Helpers
+
+    ARTIFACT = 'coverage-report-combined'
+
+    def go
+      puts 'Fetching latest code coverage data...'
+      fetch_artifact(ARTIFACT)
+      puts "Results downloaded to #{ARTIFACT}"
+      cmd = "open #{ARTIFACT}/index.html"
+      puts cmd
+      exec cmd
+    end
+  end
+end

--- a/lib/stoat/perf.rb
+++ b/lib/stoat/perf.rb
@@ -1,78 +1,44 @@
 # frozen_string_literal: true
 
-require 'fileutils'
-require 'zip'
-
+require_relative 'artifact_helpers'
 require_relative 'helpers'
 require_relative 'perf_results_evaluator'
 
 module Stoat
   # Perf - for fetching and evaluating performance test results
   class Perf
+    include ArtifactHelpers
     include Helpers
 
-    NAME = 'performance-test-results'
+    ALLOCS_THRESHOLD = 1.0
+    ARTIFACT = 'performance-test-results'
     RESULTS_FILE = 'performance_results.md'
     TIME_THRESHOLD = 3.0
-    ALLOCS_THRESHOLD = 1.0
 
     def go
-      fetch_latest
+      puts 'Fetching latest performance test results...'
+      fetch_artifact(ARTIFACT, cleanup_routine:)
+      file_utils.mv File.join(ARTIFACT, RESULTS_FILE), File.join(Dir.pwd, RESULTS_FILE)
+      file_utils.rm_rf ARTIFACT
+      puts "Results available at '#{RESULTS_FILE}'"
       report
     end
 
     private
 
-    # TODO: error handling
-    def artifact_url
-      github.repository_artifacts(REPO).artifacts.detect { |a| a.name == NAME }.archive_download_url
-    end
+    def cleanup_routine
+      proc do
+        bail "Failed to extract '#{RESULTS_FILE}'" unless File.exist?(RESULTS_FILE)
 
-    def cleanup_results
-      bail "Failed to extract '#{RESULTS_FILE}'" unless File.exist?(RESULTS_FILE)
-
-      data = File.read(RESULTS_FILE).split("\n")
-      first_md_line_idx = data.find_index { |line| line.start_with?('|') }
-      file_utils.rm_f(RESULTS_FILE)
-      File.write(RESULTS_FILE, data[first_md_line_idx..].join("\n"))
-    end
-
-    def fetch_latest
-      puts 'Fetching latest performance test results...'
-      data = grab_latest_zip_blob
-      write_zip(data)
-      unzip_zip
-      cleanup_results
-      puts "File written to #{RESULTS_FILE}"
-    end
-
-    def file_utils
-      @file_utils ||= FileUtils
-    end
-
-    def grab_latest_zip_blob
-      github.get(artifact_url)
+        data = File.read(RESULTS_FILE).split("\n")
+        first_md_line_idx = data.find_index { |line| line.start_with?('|') }
+        file_utils.rm_f(RESULTS_FILE)
+        File.write(RESULTS_FILE, data[first_md_line_idx..].join("\n"))
+      end
     end
 
     def report
       PerfResultsEvaluator.new(RESULTS_FILE).evaluate
-    end
-
-    # TODO: can we not simply unzip the data blob without writing it to disk
-    #       first?
-    def unzip_zip
-      file_utils.rm_f(RESULTS_FILE)
-      Zip::File.open(zip_file) { |z| z.first.extract }
-      file_utils.rm_f(zip_file)
-    end
-
-    def write_zip(data)
-      file_utils.rm_f zip_file
-      File.write(zip_file, data)
-    end
-
-    def zip_file
-      @zip_file ||= "#{RESULTS_FILE}.zip"
     end
   end
 end

--- a/lib/stoat/version.rb
+++ b/lib/stoat/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stoat
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/test/test_coverage.rb
+++ b/test/test_coverage.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# TestCoverage - test lib/coverage.rb
+class TestCoverage < Minitest::Test
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/BlockLength
+  def test_go
+    opwd = Dir.pwd
+    Dir.mktmpdir do |dir|
+      Dir.chdir dir
+      stoat = Stoat::Coverage.new
+      def stoat.puts(_txt); end
+
+      def stoat.exec(_cmd)
+        'execed'
+      end
+
+      github_mock = MiniTest::Mock.new
+      stoat.instance_variable_set(:@github_mock, github_mock)
+      artifact_mock = MiniTest::Mock.new
+      artifact_mock.expect :name, Stoat::Coverage::ARTIFACT
+      fake_url = 'rupert://davies'
+      artifact_mock.expect :archive_download_url, fake_url
+      repository_artifacts_mock = MiniTest::Mock.new
+      repository_artifacts_mock.expect :artifacts, [artifact_mock]
+      github_mock.expect :repository_artifacts, repository_artifacts_mock, [Stoat::Helpers::REPO]
+      github_mock.expect :get, nil, [fake_url]
+
+      def stoat.github
+        @github_mock
+      end
+
+      extractable = []
+      def extractable.extract; end
+
+      Zip::File.stub :open, nil, [extractable] do
+        stoat.go
+      end
+
+      github_mock.verify
+      artifact_mock.verify
+      repository_artifacts_mock.verify
+    end
+  ensure
+    Dir.chdir opwd
+  end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/BlockLength
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'simplecov'
+require 'simplecov' unless ENV['NOCOV']
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'stoat'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,5 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'stoat'
 
 require 'minitest/autorun'
+
+ENV[Stoat::Helpers::TOKEN_ENV_VAR] = 'fake-token-to-help-prevent-real-github-api-calls'

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -9,6 +9,23 @@ class TestHelpers < Minitest::Test
     attr_accessor :message
   end
 
+  def test_access_token
+    value = 'Slippers weather'
+    ENV.stub :key, true, [Stoat::Helpers::TOKEN_ENV_VAR] do
+      ENV.stub :fetch, value, [Stoat::Helpers::TOKEN_ENV_VAR] do
+        assert_equal value, Tester.new.access_token
+      end
+    end
+  end
+
+  def test_access_token_with_env_var_not_set
+    ENV.stub :key?, false, [Stoat::Helpers::TOKEN_ENV_VAR] do
+      tester = Tester.new
+      def tester.warn(_msg); end
+      assert_raises(SystemExit) { tester.access_token }
+    end
+  end
+
   def test_bail
     tester = Tester.new
     msg = 'Fear causes hesitation, and hesitation will cause your worst fears to come true.'
@@ -19,5 +36,19 @@ class TestHelpers < Minitest::Test
 
     assert_raises(SystemExit) { tester.bail msg }
     assert_equal msg, tester.message
+  end
+
+  def test_github
+    token = 'NES Kirby'
+    tester = Tester.new
+    tester.instance_variable_set(:@token, token)
+
+    def tester.access_token
+      @token
+    end
+
+    gh = tester.github
+    assert_kind_of Octokit::Client, gh
+    assert_equal token, gh.access_token
   end
 end


### PR DESCRIPTION
v0.0.3 - run `stoat coverage` to fetch and view the latest combined code coverage results